### PR TITLE
fixed CCM metric

### DIFF
--- a/src/main/java/org/jpeek/calculus/java/fix/Ccm.java
+++ b/src/main/java/org/jpeek/calculus/java/fix/Ccm.java
@@ -1,0 +1,286 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2019 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.jpeek.calculus.java.fix;
+
+import com.jcabi.xml.XML;
+import com.jcabi.xml.XMLDocument;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.jpeek.graph.java.FindConnectedComponents;
+
+/**
+ * Application.
+ * <p>There is no thread-safety guarantee.
+ *
+ * @since 1.0.0
+ * @checkstyle NestedIfDepthCheck (300 lines)
+ * @checkstyle MagicNumberCheck (300 lines)
+ * @checkstyle ExecutableStatementCountCheck (300 lines)
+ */
+public final class Ccm {
+
+    /**
+     * XML Skeleton.
+     */
+    private final XML skeleton;
+
+    /**
+     * The transformed XML skeleton.
+     */
+    private final XML tempres;
+
+    /**
+     * Initializes object of class for fixing NCC value of CCM metric.
+     *
+     * @param skeleton XML Skeleton
+     * @param tempres The Transformed XML skeleton.
+     */
+    public Ccm(final XML skeleton, final XML tempres) {
+        this.skeleton = skeleton;
+        this.tempres = tempres;
+    }
+
+    /**
+     * Updates the transformed xml with proper NCC value.
+     *
+     * @return XML with fixed NCC.
+     */
+    @SuppressWarnings("PMD.AvoidDuplicateLiterals")
+    public XML getFixedResult() {
+        final List<String> packages = this.skeleton.xpath("//package/@id");
+        String finalres = "";
+        if (this.tempres.toString().indexOf("<package") > 6) {
+            finalres = this.tempres.toString().substring(
+                0,
+                this.tempres.toString().indexOf("<package") - 6
+            );
+        }
+        for (final String apackage : packages) {
+            finalres = finalres.concat(
+                String.format(
+                    "      <package id=\"%s\">\n",
+                    apackage
+                )
+            );
+            final List<String> classes = this.skeleton.xpath(
+                String.format(
+                    "//package[@id ='%s']/class/@id",
+                    apackage
+                )
+            );
+            for (final String aclass : classes) {
+                finalres = this.calc(aclass, finalres);
+            }
+            finalres = finalres.concat("      </package>\n");
+        }
+        if (this.tempres.toString().indexOf("</app") > 1) {
+            finalres = finalres.concat(
+                this.tempres.toString().substring(
+                    this.tempres.toString().indexOf("</app")
+                )
+            );
+        }
+        return new XMLDocument(finalres);
+    }
+
+    /**
+     * Calculates class value.
+     * @param aclass XML class as String
+     * @param finalres Final result of whole project
+     * @return Final result with class value
+     */
+    @SuppressWarnings({
+        "PMD.AvoidDuplicateLiterals",
+        "PMD.CyclomaticComplexity",
+        "PMD.NPathComplexity"
+    })
+    private String calc(final String aclass, final String finalres) {
+        final List<XML> methods = this.skeleton.nodes(
+            String.format(
+                "//class[@id ='%s']/methods/method[@ctor='false' and @abstract='false']",
+                aclass
+            )
+        );
+        final List<XML> edges = this.tempres.nodes(
+            String.format(
+                "//class[@id =\"%s\"]/vars/edges/edge",
+                aclass
+            )
+        );
+        String classpattern;
+        int ncc = 0;
+        final double nco = Double.parseDouble(
+            this.tempres.xpath(
+                String.format(
+                    "//class[@id ='%s']/vars/var[@id =\"nc\"]/text()",
+                    aclass
+                )
+            ).get(0)
+        );
+        final double nmp = Double.parseDouble(
+            this.tempres.xpath(
+                String.format(
+                    "//class[@id ='%s']/vars/var[@id =\"nmp\"]/text()",
+                    aclass
+                )
+            ).get(0)
+        );
+        if (methods.size() > 1) {
+            ncc = getNcc(
+                methods,
+                edges
+            );
+            final double value = nco / (nmp * ncc);
+            classpattern = String.format(
+                "         <class id=\"%s\" value=\"%s\">\n",
+                aclass,
+                value
+            );
+        } else {
+            classpattern = String.format(
+                "         <class id=\"%s\" value=\"NaN\">\n",
+                aclass
+            );
+        }
+        classpattern = classpattern.concat(
+            String.format(
+                "%s%s%s%s%s",
+                "            <vars>\n",
+                String.format(
+                    "               <var id=\"methods\">%s</var>\n",
+                    methods.size()
+                ),
+                String.format(
+                    "               <var id=\"nc\">%s</var>\n",
+                    nco
+                ),
+                String.format(
+                    "               <var id=\"ncc\">%s</var>\n",
+                    ncc
+                ),
+                String.format(
+                    "               <var id=\"nmp\">%s</var>\n",
+                    nmp
+                )
+            )
+        );
+        classpattern = classpattern.concat(
+            "            </vars>\n         </class>\n"
+        );
+        return finalres.concat(classpattern);
+    }
+
+    /**
+     * Gets class methods and calls class for searching number of connected components.
+     * @param methods List of methods
+     * @param edges List of connections among methods
+     * @return Number of connected components
+     */
+    @SuppressWarnings({
+        "PMD.AvoidDuplicateLiterals",
+        "PMD.CyclomaticComplexity",
+        "PMD.NPathComplexity"
+    })
+    private static int getNcc(final List<XML> methods, final List<XML> edges) {
+        final Map<String, Integer> methodids = new HashMap<>();
+        for (int methodind = 0; methodind < methods.size(); methodind += 1) {
+            final String name = methods.get(methodind).node()
+                .getAttributes().getNamedItem("name").getNodeValue();
+            final String desc = methods.get(methodind).node()
+                .getAttributes().getNamedItem("desc").getNodeValue();
+            methodids.put(name + desc, methodind);
+        }
+        final Pattern pattern = Pattern.compile(
+            String.format(
+                "%s%s%s",
+                "<method>[\\n\\r\\s]+<name>(\\w+)<\\/name>[\\n\\r\\s]+",
+                "(<desc>([\\n\\r\\s\\w;\\/()]+)<\\/desc>",
+                "|<desc\\/>)[\\n\\r\\s]+<\\/method>"
+            )
+        );
+        final FindConnectedComponents compsearch =
+            new FindConnectedComponents(
+                methods.size()
+            );
+        compsearch.initGraph();
+        for (final XML method : edges) {
+            final Matcher name = pattern.matcher(method.toString());
+            int from = -1;
+            int eto = -1;
+            if (name.find()) {
+                if (name.group(2).equals("<desc/>")) {
+                    from = methodids.get(
+                        clearSpaces(
+                            name.group(1)
+                        )
+                    );
+                } else {
+                    from = methodids.get(
+                        clearSpaces(
+                            String.format(
+                                "%s%s",
+                                name.group(1),
+                                name.group(3)
+                            )
+                        )
+                    );
+                }
+            }
+            if (name.find()) {
+                if (name.group(2).equals("<desc/>")) {
+                    eto = methodids.get(
+                        clearSpaces(name.group(1))
+                    );
+                } else {
+                    eto = methodids.get(
+                        clearSpaces(
+                            String.format(
+                                "%s%s",
+                                name.group(1),
+                                name.group(3)
+                            )
+                        )
+                    );
+                }
+            }
+            if (from != -1 && eto != -1) {
+                compsearch.addEdge(from, eto);
+            }
+        }
+        return compsearch.connectedComponents();
+    }
+
+    /**
+     * Clears extra spaces in final result.
+     * @param old String with extra spaces
+     * @return String without extra spaces
+     */
+    private static String clearSpaces(final String old) {
+        return old.replace(" ", "").replace("\n", "");
+    }
+}
+

--- a/src/main/java/org/jpeek/calculus/java/fix/package-info.java
+++ b/src/main/java/org/jpeek/calculus/java/fix/package-info.java
@@ -21,43 +21,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.jpeek.calculus.xsl;
-
-import com.jcabi.xml.Sources;
-import com.jcabi.xml.XML;
-import com.jcabi.xml.XSLDocument;
-import java.io.IOException;
-import java.util.Map;
-import org.cactoos.io.ResourceOf;
-import org.cactoos.text.FormattedText;
-import org.cactoos.text.TextOf;
-import org.jpeek.calculus.Calculus;
-import org.jpeek.calculus.java.fix.Ccm;
 
 /**
- * Metrics xsl calculus. Use an xsl sheet to transform the input skeleton into
- * the xml containing the calculation.
- * @since 0.30.9
+ * JPeek java metric CCM calculation fix.
+ *
+ * @since 1.0-SNAPSHOT
  */
-public final class XslCalculus implements Calculus {
-
-    @Override
-    public XML node(final String metric, final Map<String, Object> params,
-        final XML skeleton) throws IOException {
-        XML tempxsl = new XSLDocument(
-            new TextOf(
-                new ResourceOf(
-                    new FormattedText("org/jpeek/metrics/%s.xsl", metric)
-                )
-            ).asString(),
-            Sources.DUMMY,
-            params
-        ).transform(skeleton);
-        if (metric.equals("CCM")) {
-            tempxsl = new Ccm(skeleton, tempxsl).getFixedResult();
-        }
-        return tempxsl;
-    }
-
-}
+package org.jpeek.calculus.java.fix;
 

--- a/src/main/java/org/jpeek/graph/java/FindConnectedComponents.java
+++ b/src/main/java/org/jpeek/graph/java/FindConnectedComponents.java
@@ -1,0 +1,108 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2019 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.jpeek.graph.java;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Find connected components of graph.
+ * @since 1.0.0
+ */
+public class FindConnectedComponents {
+
+    /**
+     * Number of vertices.
+     */
+    private final int vnumber;
+
+    /**
+     * List of vertices with connections.
+     */
+    private final List<List<Integer>> graph;
+
+    /**
+     * Initializes instance of class.
+     *
+     * @param vnumber Number of vertices in graph
+     */
+    public FindConnectedComponents(final int vnumber) {
+        this.vnumber = vnumber;
+        this.graph = new ArrayList<>(vnumber);
+    }
+
+    /**
+     * Initializes graph based ob vertices number.
+     */
+    public void initGraph() {
+        for (int ind = 0; ind < this.vnumber; ind += 1) {
+            this.graph.add(ind, new ArrayList<>(this.vnumber));
+        }
+    }
+
+    /**
+     * Searches for connected components.
+     *
+     * @return Number of connected components
+     */
+    public int connectedComponents() {
+        int ccc = 0;
+        final boolean[] visited = new boolean[this.vnumber];
+        for (int indv = 0; indv < this.vnumber; indv += 1) {
+            if (!visited[indv]) {
+                this.dfs(indv, visited);
+                ccc += 1;
+            }
+        }
+        return ccc;
+    }
+
+    /**
+     * Creates direct edges in graph.
+     *
+     * @param src Vertice where connection starts
+     * @param dest Vertice where connection ends
+     */
+    public void addEdge(final int src, final int dest) {
+        this.graph.get(src).add(dest);
+        this.graph.get(dest).add(src);
+    }
+
+    /**
+     * Recurrent method for depth first search.
+     *
+     * @param vertice Current vertice
+     * @param visited Array of visited vertices
+     */
+    @SuppressWarnings("PMD.UseVarargs")
+    void dfs(final int vertice, final boolean[] visited) {
+        visited[vertice] = true;
+        for (final int ver : this.graph.get(vertice)) {
+            if (!visited[ver]) {
+                this.dfs(ver, visited);
+            }
+        }
+    }
+}
+

--- a/src/main/java/org/jpeek/graph/java/package-info.java
+++ b/src/main/java/org/jpeek/graph/java/package-info.java
@@ -21,43 +21,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.jpeek.calculus.xsl;
-
-import com.jcabi.xml.Sources;
-import com.jcabi.xml.XML;
-import com.jcabi.xml.XSLDocument;
-import java.io.IOException;
-import java.util.Map;
-import org.cactoos.io.ResourceOf;
-import org.cactoos.text.FormattedText;
-import org.cactoos.text.TextOf;
-import org.jpeek.calculus.Calculus;
-import org.jpeek.calculus.java.fix.Ccm;
 
 /**
- * Metrics xsl calculus. Use an xsl sheet to transform the input skeleton into
- * the xml containing the calculation.
- * @since 0.30.9
+ * JPeek java graph connected components search.
+ *
+ * @since 1.0-SNAPSHOT
  */
-public final class XslCalculus implements Calculus {
-
-    @Override
-    public XML node(final String metric, final Map<String, Object> params,
-        final XML skeleton) throws IOException {
-        XML tempxsl = new XSLDocument(
-            new TextOf(
-                new ResourceOf(
-                    new FormattedText("org/jpeek/metrics/%s.xsl", metric)
-                )
-            ).asString(),
-            Sources.DUMMY,
-            params
-        ).transform(skeleton);
-        if (metric.equals("CCM")) {
-            tempxsl = new Ccm(skeleton, tempxsl).getFixedResult();
-        }
-        return tempxsl;
-    }
-
-}
+package org.jpeek.graph.java;
 

--- a/src/main/resources/org/jpeek/metrics/CCM.xsl
+++ b/src/main/resources/org/jpeek/metrics/CCM.xsl
@@ -50,10 +50,20 @@ SOFTWARE.
           <xsl:if test="$method/ops/op/text()[. = $other/ops/op/text()]">
             <edge>
               <method>
-                <xsl:value-of select="$method/@name"/>
+                <name>
+                  <xsl:value-of select="$method/@name"/>
+                </name>
+                <desc>
+                  <xsl:value-of select="$method/@desc"/>
+                </desc>
               </method>
               <method>
-                <xsl:value-of select="$other/@name"/>
+                <name>
+                  <xsl:value-of select="$other/@name"/>
+                </name>
+                <desc>
+                  <xsl:value-of select="$other/@desc"/>
+                </desc>
               </method>
             </edge>
           </xsl:if>
@@ -88,6 +98,9 @@ SOFTWARE.
         <var id="nmp">
           <xsl:value-of select="$nmp"/>
         </var>
+        <edges>
+          <xsl:copy-of select="$edges"/>
+        </edges>
       </vars>
     </xsl:copy>
   </xsl:template>

--- a/src/main/resources/org/jpeek/xsd/metric.xsd
+++ b/src/main/resources/org/jpeek/xsd/metric.xsd
@@ -50,6 +50,11 @@ SOFTWARE.
                 </xs:simpleContent>
               </xs:complexType>
             </xs:element>
+            <xs:element name="edges" minOccurs="0" maxOccurs="unbounded">
+              <xs:annotation>
+                <xs:documentation>List of class method relationships - edges</xs:documentation>
+              </xs:annotation>
+            </xs:element>
           </xs:sequence>
         </xs:complexType>
         <xs:unique name="varUnique">

--- a/src/test/resources/org/jpeek/metricstest-params.csv
+++ b/src/test/resources/org/jpeek/metricstest-params.csv
@@ -114,9 +114,9 @@ WithoutAttributes,CCM,NaN
 OneMethodCreatesLambda,CCM,NaN
 OneVoidMethodWithoutParams,CCM,NaN
 #Bar,CCM,0.2222d
-Foo,CCM,0.5d
+Foo,CCM,1.0d
 OverloadMethods,CCM,1.0d
-TwoCommonAttributes,CCM,NaN
+TwoCommonAttributes,CCM,0.0d
 #TwoCommonMethods,CCM,0.0333d
 Bar,MWE,1.0d
 Foo,MWE,1.0d


### PR DESCRIPTION
Fixed calculation of CCM metric. Added changes to metric.xsd and CCM.xsl for writting temporary information: relations between methods represented as _<graph><edge/></graph>_

Also found and fixed mistakes in CCM test values of classes Foo and TwoCommonAttributes.
Mistakes explanation:

- Foo class has 2 methods, both of them access attribute name. This means that NC number of connected methods is 1, NCC is also 1, NMP between 2 methods is 1. Value will be 1.
- TwoCommonAttributes class has 3 methods. None of pairs of methods call or access common method or attribute. NC is 0. NCC is equal 3. NMP between 3 methods is 3. Value will be 0. CCM metric can not have NaN values if number of methods more than 1.