### PR TITLE
Fixed some warnings, appearing during clean install

### DIFF
--- a/src/test/java/org/jpeek/skeleton/SkeletonTest.java
+++ b/src/test/java/org/jpeek/skeleton/SkeletonTest.java
@@ -92,8 +92,8 @@ final class SkeletonTest {
                 "//class/methods[count(method)=7]",
                 "//method[@name='methodSix']/args[count(arg)=1]",
                 "//method[@name='methodSix']/args/arg[@type='Ljava/sql/Timestamp']",
-                "//method[@name='methodSix' and return='Ljava/util/Date']",
-                "//method[@name='methodTwo' and return='V']",
+                "//method[@name='methodSix' and child::return='Ljava/util/Date']",
+                "//method[@name='methodTwo' and child::return='V']",
                 "//method[@name='methodOne']/args/arg[@type='Ljava/lang/Object']"
             )
         ).affirm();

--- a/src/test/java/org/jpeek/skeleton/TypesOfTest.java
+++ b/src/test/java/org/jpeek/skeleton/TypesOfTest.java
@@ -50,7 +50,7 @@ final class TypesOfTest {
             XhtmlMatchers.hasXPaths(
                 "/method/args[count(arg) = 2]",
                 "/method/args/arg[@type = 'Ljava/lang/String']",
-                "/method[return='Z']"
+                "/method[child::return='Z']"
             )
         ).affirm();
     }


### PR DESCRIPTION
Fixed warnings in Skeleton test appearing during clean install: "the keyword return in this context means child::return"