### PR TITLE
[#522] Tests for CCM calculations

### DIFF
--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -10,6 +10,7 @@ name: mvn
 jobs:
   maven-build:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     strategy:
       matrix:
         os: [ubuntu-22.04, windows-latest, macos-latest]

--- a/pom.xml
+++ b/pom.xml
@@ -301,6 +301,7 @@ SOFTWARE.
           <plugin>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>
+            <version>0.8.11</version>
             <configuration>
               <output>file</output>
             </configuration>

--- a/src/test/java/org/jpeek/metrics/CcmTest.java
+++ b/src/test/java/org/jpeek/metrics/CcmTest.java
@@ -1,0 +1,110 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2024 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.jpeek.metrics;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests to check CCM metric in different links between attributes and methods.
+ * @since 0.29
+ */
+@Disabled
+final class CcmTest {
+
+    /**
+     * Class with one method access one attribute have
+     * ncc metric = methods count.
+     * @throws Exception
+     */
+    @Test
+    void manyComponentInClassTest() throws Exception {
+        final MetricBase.Report report = new MetricBase(
+            "org/jpeek/metrics/CCM.xsl"
+        ).transform(
+            "CcmManyComp"
+        );
+        report.assertVariable("methods", 5);
+        report.assertVariable("nc", 0);
+        report.assertVariable("nmp", 10);
+        report.assertVariable("ncc", 5);
+        report.assertValue(0.0f, 0.001f);
+    }
+
+    /**
+     * Class with one method access one attribute and
+     * Ctor with all attributes initialization have the same
+     * metric as without Ctor.
+     * @throws Exception
+     */
+    @Test
+    void manyComponentWithCtorInClassTest() throws Exception {
+        final MetricBase.Report report = new MetricBase(
+            "org/jpeek/metrics/CCM.xsl"
+        ).transform(
+            "CcmManyCompWithCtor"
+        );
+        report.assertVariable("methods", 5);
+        report.assertVariable("nc", 0);
+        report.assertVariable("nmp", 10);
+        report.assertVariable("ncc", 5);
+        report.assertValue(0.0f, 0.001f);
+    }
+
+    @Test
+    void oneComponentInClassTest() throws Exception {
+        final MetricBase.Report report = new MetricBase(
+            "org/jpeek/metrics/CCM.xsl"
+        ).transform(
+            "CcmOneComp"
+        );
+        report.assertVariable("methods", 5);
+        report.assertVariable("nc", 10);
+        report.assertVariable("nmp", 10);
+        report.assertVariable("ncc", 1);
+        report.assertValue(1.0f, 0.001f);
+    }
+
+    /**
+     * Check ccm metric for mixed usage: attribute usage, methods calls.
+     * @todo #522:30min there is a 4th step for incorrect calculation: nc
+     *  in case of calling one method from another because of
+     *  `xsl:if test="$method/ops/op/text()[. = $other/ops/op/text()]"`
+     *  method name is not used for creating edge.
+     * @throws Exception
+     */
+    @Test
+    void mixedCallsInClassTest() throws Exception {
+        final MetricBase.Report report = new MetricBase(
+            "org/jpeek/metrics/CCM.xsl"
+        ).transform(
+            "CcmMixCallManyComp"
+        );
+        report.assertVariable("methods", 5);
+        report.assertVariable("nc", 2);
+        report.assertVariable("nmp", 10);
+        report.assertVariable("ncc", 3);
+        report.assertValue(0.0666f, 0.0001f);
+    }
+}

--- a/src/test/resources/org/jpeek/samples/CcmManyComp.java
+++ b/src/test/resources/org/jpeek/samples/CcmManyComp.java
@@ -1,0 +1,33 @@
+public class CcmManyComp {
+
+    String name1;
+
+    String name2;
+
+    String name3;
+
+    String name4;
+
+    String name5;
+
+    public void one() {
+        name1 = "1";
+    }
+
+    public void two() {
+        name2 = "2";
+    }
+
+    public void three() {
+        name3 = "3";
+    }
+
+    public void four() {
+        name4 = "4";
+    }
+
+    public void five() {
+        name5 = "5";
+    }
+
+}

--- a/src/test/resources/org/jpeek/samples/CcmManyCompWithCtor.java
+++ b/src/test/resources/org/jpeek/samples/CcmManyCompWithCtor.java
@@ -1,0 +1,41 @@
+public class CcmManyCompWithCtor {
+
+    String name1;
+
+    String name2;
+
+    String name3;
+
+    String name4;
+
+    String name5;
+
+    public CcmManyComponentWithCtor() {
+        name1 = "one";
+        name2 = "two";
+        name3 = "three";
+        name4 = "four";
+        name5 = "five";
+    }
+
+    public void one() {
+        name1 = "1";
+    }
+
+    public void two() {
+        name2 = "2";
+    }
+
+    public void three() {
+        name3 = "3";
+    }
+
+    public void four() {
+        name4 = "4";
+    }
+
+    public void five() {
+        name5 = "5";
+    }
+
+}

--- a/src/test/resources/org/jpeek/samples/CcmMixCallManyComp.java
+++ b/src/test/resources/org/jpeek/samples/CcmMixCallManyComp.java
@@ -1,0 +1,29 @@
+public class CcmMixCallManyComp {
+
+    String name1;
+
+    String name3;
+
+    String name5;
+
+    public void one() {
+        name1 = "1";
+    }
+
+    public void two() {
+        name1 = "2";
+    }
+
+    public void three() {
+        name3 = "3";
+    }
+
+    public void four() {
+        this.three();
+    }
+
+    public void five() {
+        name5 = "5";
+    }
+
+}

--- a/src/test/resources/org/jpeek/samples/CcmOneComp.java
+++ b/src/test/resources/org/jpeek/samples/CcmOneComp.java
@@ -1,0 +1,25 @@
+public class CcmOneComponent {
+
+    String name;
+
+    public void one() {
+        name = "1";
+    }
+
+    public void two() {
+        name = "2";
+    }
+
+    public void three() {
+        name = "3";
+    }
+
+    public void four() {
+        name = "4";
+    }
+
+    public void five() {
+        name = "5";
+    }
+
+}


### PR DESCRIPTION
- disabled test with manually calculated ccm (and all parts)
- one more issue for nc calculation
- update jacoco plugin (0.8.8 produce a error on jdk 17+)
- limit mvn job execution to 1 hour