### PR TITLE
Ccm constructor

### DIFF
--- a/src/test/java/org/jpeek/metrics/CcmTest.java
+++ b/src/test/java/org/jpeek/metrics/CcmTest.java
@@ -52,6 +52,20 @@ final class CcmTest {
         report.assertValue(0.0f, 0.001f);
     }
 
+    @Test
+    void oneComponentInClassTest() throws Exception {
+        final MetricBase.Report report = new MetricBase(
+                "org/jpeek/metrics/CCM.xsl"
+        ).transform(
+                "CcmOneComp"
+        );
+        report.assertVariable("methods", 5);
+        report.assertVariable("nc", 10);
+        report.assertVariable("nmp", 10);
+        report.assertVariable("ncc", 1);
+        report.assertValue(1.0f, 0.001f);
+    }
+
     /**
      * Class with one method access one attribute and
      * Ctor with all attributes initialization have the same
@@ -70,20 +84,6 @@ final class CcmTest {
         report.assertVariable("nmp", 10);
         report.assertVariable("ncc", 5);
         report.assertValue(0.0f, 0.001f);
-    }
-
-    @Test
-    void oneComponentInClassTest() throws Exception {
-        final MetricBase.Report report = new MetricBase(
-            "org/jpeek/metrics/CCM.xsl"
-        ).transform(
-            "CcmOneComp"
-        );
-        report.assertVariable("methods", 5);
-        report.assertVariable("nc", 10);
-        report.assertVariable("nmp", 10);
-        report.assertVariable("ncc", 1);
-        report.assertValue(1.0f, 0.001f);
     }
 
     /**

--- a/src/test/java/org/jpeek/metrics/CcmTest.java
+++ b/src/test/java/org/jpeek/metrics/CcmTest.java
@@ -52,20 +52,6 @@ final class CcmTest {
         report.assertValue(0.0f, 0.001f);
     }
 
-    @Test
-    void oneComponentInClassTest() throws Exception {
-        final MetricBase.Report report = new MetricBase(
-                "org/jpeek/metrics/CCM.xsl"
-        ).transform(
-                "CcmOneComp"
-        );
-        report.assertVariable("methods", 5);
-        report.assertVariable("nc", 10);
-        report.assertVariable("nmp", 10);
-        report.assertVariable("ncc", 1);
-        report.assertValue(1.0f, 0.001f);
-    }
-
     /**
      * Class with one method access one attribute and
      * Ctor with all attributes initialization have the same
@@ -84,6 +70,20 @@ final class CcmTest {
         report.assertVariable("nmp", 10);
         report.assertVariable("ncc", 5);
         report.assertValue(0.0f, 0.001f);
+    }
+
+    @Test
+    void oneComponentInClassTest() throws Exception {
+        final MetricBase.Report report = new MetricBase(
+            "org/jpeek/metrics/CCM.xsl"
+        ).transform(
+            "CcmOneComp"
+        );
+        report.assertVariable("methods", 5);
+        report.assertVariable("nc", 10);
+        report.assertVariable("nmp", 10);
+        report.assertVariable("ncc", 1);
+        report.assertValue(1.0f, 0.001f);
     }
 
     /**

--- a/src/test/resources/org/jpeek/samples/CcmManyCompWithCtor.java
+++ b/src/test/resources/org/jpeek/samples/CcmManyCompWithCtor.java
@@ -10,7 +10,7 @@ public class CcmManyCompWithCtor {
 
     String name5;
 
-    public CcmManyComponentWithCtor() {
+    public CcmManyCompWithCtor() {
         name1 = "one";
         name2 = "two";
         name3 = "three";

--- a/src/test/resources/org/jpeek/samples/CcmOneComp.java
+++ b/src/test/resources/org/jpeek/samples/CcmOneComp.java
@@ -1,4 +1,4 @@
-public class CcmOneComponent {
+public class CcmOneComp {
 
     String name;
 


### PR DESCRIPTION
constructor in src/test/resources/org/jpeek/samples/CcmManyCompWithCtor.java had incorrect name, so the test that used that file was buggy.