### PR TITLE
fixed issue 501

### DIFF
--- a/src/main/resources/org/jpeek/metrics/TLCOM.xsl
+++ b/src/main/resources/org/jpeek/metrics/TLCOM.xsl
@@ -82,10 +82,6 @@ SOFTWARE.
            connected to m3. It will miss connections in longer chains. After fixing this, maybe we can add it to
            the standard metrics in App.
           -->
-          <!--
-          @todo #65:15min TLCOM: add test for OneMethodCreatesLambda after #171 is fixed. The extra synthetic
-           method introduced by the compiler distorts this metric's result.
-          -->
           <xsl:choose>
             <xsl:when test="$left_attrs[. = $right_attrs]">
               <Q/>

--- a/src/test/resources/org/jpeek/metricstest-params.csv
+++ b/src/test/resources/org/jpeek/metricstest-params.csv
@@ -98,6 +98,7 @@ OnlyOneMethodWithParams,TLCOM,0.0d
 OverloadMethods,TLCOM,0.0d
 #TwoCommonAttributes,TLCOM,4.0d
 WithoutAttributes,TLCOM,1.0d
+OneMethodCreatesLambda,TLCOM,1.0d
 Bar,LCC,0.0d
 Foo,LCC,1.0d
 MethodMethodCalls,LCC,0.1d


### PR DESCRIPTION
@yegor256 here is the issue #501 fixed

I added the missing test and checked its correctness. Now there is a test that checks the value of the TLCOM metric for the OneMethodCreatesLambda class
