### PR TITLE
Fix the ordering of group and artifact variables

### DIFF
--- a/src/main/java/org/jpeek/web/Futures.java
+++ b/src/main/java/org/jpeek/web/Futures.java
@@ -116,7 +116,7 @@ final class Futures implements
                         );
                         Logger.info(
                             this, "Finished processing of %s:%s",
-                            artifact, group
+                            group, artifact
                         );
                     // @checkstyle IllegalCatchCheck (4 lines)
                     // @checkstyle AvoidCatchingGenericException (4 lines)

--- a/src/test/java/org/jpeek/web/FuturesTest.java
+++ b/src/test/java/org/jpeek/web/FuturesTest.java
@@ -44,7 +44,7 @@ final class FuturesTest {
         new Assertion<>(
             "Futures returns Response",
             new Futures(
-                (artifact, group) -> input -> new RsPage(
+                (group, artifact) -> input -> new RsPage(
                     new RqFake(),
                     "wait",
                     () -> new IterableOf<>(
@@ -52,7 +52,7 @@ final class FuturesTest {
                         new XeAppend("artifact", artifact)
                     )
                 )
-            ).apply("a", "g").get().apply("test"),
+            ).apply("g", "a").get().apply("test"),
             new IsNot<>(new IsEqual<>(null))
         ).affirm();
     }
@@ -62,10 +62,10 @@ final class FuturesTest {
         new Assertion<>(
             "Futures don't crash",
             new Futures(
-                (artifact, group) -> {
+                (group, artifact) -> {
                     throw new UnsupportedOperationException("intended");
                 }
-            ).apply("a1", "g1").get().apply("test-2"),
+            ).apply("g1", "a1").get().apply("test-2"),
             new IsNot<>(new IsEqual<>(null))
         ).affirm();
     }


### PR DESCRIPTION
Fix for the issue mentioned in #564. I made sure that the ordering of group and artifact variables is consistent.