### PR TITLE
Extend the App.java test

### DIFF
--- a/src/test/java/org/jpeek/AppTest.java
+++ b/src/test/java/org/jpeek/AppTest.java
@@ -71,17 +71,21 @@ final class AppTest {
     }
 
     @Test
-    void canIncludePrivateMethods(@TempDir final Path output) throws Exception {
+    void canIncludeAllMethods(@TempDir final Path output) throws Exception {
         final Path input = Paths.get(".");
         final Map<String, Object> args = new HashMap<>();
+        args.put("include-ctors", 1);
+        args.put("include-static-methods", 1);
         args.put("include-private-methods", 1);
         new App(input, output, args).analyze();
         new Assertion<>(
-            "Must contain private method",
+            "Must contain all types of methods",
             XhtmlMatchers.xhtml(
                 new TextOf(output.resolve("skeleton.xml")).asString()
             ),
             XhtmlMatchers.hasXPaths(
+                "//method[@ctor='true']",
+                "//method[@static='true']",
                 "//method[@visibility='private']"
             )
         ).affirm();

--- a/src/test/java/org/jpeek/AppTest.java
+++ b/src/test/java/org/jpeek/AppTest.java
@@ -79,7 +79,7 @@ final class AppTest {
         args.put("include-private-methods", 1);
         new App(input, output, args).analyze();
         new Assertion<>(
-            "Must contain all types of methods",
+            "Must contain all included methods",
             XhtmlMatchers.xhtml(
                 new TextOf(output.resolve("skeleton.xml")).asString()
             ),

--- a/src/test/java/org/jpeek/AppTest.java
+++ b/src/test/java/org/jpeek/AppTest.java
@@ -71,22 +71,52 @@ final class AppTest {
     }
 
     @Test
-    void canIncludeAllMethods(@TempDir final Path output) throws Exception {
+    void canIncludePrivateMethods(@TempDir final Path output) throws Exception {
         final Path input = Paths.get(".");
         final Map<String, Object> args = new HashMap<>();
-        args.put("include-ctors", 1);
-        args.put("include-static-methods", 1);
         args.put("include-private-methods", 1);
         new App(input, output, args).analyze();
         new Assertion<>(
-            "Must contain all included methods",
+            "Must contain private method",
             XhtmlMatchers.xhtml(
                 new TextOf(output.resolve("skeleton.xml")).asString()
             ),
             XhtmlMatchers.hasXPaths(
-                "//method[@ctor='true']",
-                "//method[@static='true']",
                 "//method[@visibility='private']"
+            )
+        ).affirm();
+    }
+
+    @Test
+    void canIncludeConstructors(@TempDir final Path output) throws Exception {
+        final Path input = Paths.get(".");
+        final Map<String, Object> args = new HashMap<>();
+        args.put("include-ctors", 1);
+        new App(input, output, args).analyze();
+        new Assertion<>(
+            "Must contain constructor",
+            XhtmlMatchers.xhtml(
+                new TextOf(output.resolve("skeleton.xml")).asString()
+            ),
+            XhtmlMatchers.hasXPaths(
+                "//method[@ctor='true']"
+            )
+        ).affirm();
+    }
+
+    @Test
+    void canIncludeStaticMethods(@TempDir final Path output) throws Exception {
+        final Path input = Paths.get(".");
+        final Map<String, Object> args = new HashMap<>();
+        args.put("include-static-methods", 1);
+        new App(input, output, args).analyze();
+        new Assertion<>(
+            "Must contain static method",
+            XhtmlMatchers.xhtml(
+                new TextOf(output.resolve("skeleton.xml")).asString()
+            ),
+            XhtmlMatchers.hasXPaths(
+                "//method[@static='true']"
             )
         ).affirm();
     }


### PR DESCRIPTION
Previously, only the  `include-private-methods` flag was tested. I added the `include-static-methods` and `include-ctors` flags to the test. The same thing could be achieved by adding two tests, one for each of the flags, but I decided against this as it would add a lot of duplicate code.